### PR TITLE
bin/keep

### DIFF
--- a/bin/keep
+++ b/bin/keep
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "usage: $(basename $0) [-h|--help]"
+  echo
+  echo 'Keep is a tool for keeping or removing files from an arbitrary list,'
+  echo 'interactively. It takes zero or more lines from STDIN and for each one'
+  echo 'prompts the user to choose whether to keep (the default) or remove'
+  echo 'that file.'
+  echo
+  echo '  EXAMPLE:'
+  echo
+  echo '  $ ls | keep'
+  echo
+  echo '  OPTIONS:'
+  echo
+  echo '  -h|--help show this help text'
+}
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -h|--help)
+    # show usage and bail
+    usage
+    exit
+    ;;
+    -d|--dry-run)
+    DRY_RUN=1
+    shift # past argument
+    ;;
+    -y|--arg-with-value)
+    VALARG="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    *)
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+esac
+
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+
+opts='-rf' # TODO
+while read file; do
+  read -p "Keep $file (Y/n)? [Ctrl+C to quit] " choice < /dev/tty
+  if [[ $choice == 'n' ]] ; then
+    if [[ $DRY_RUN ]] ; then
+      echo rm $opts $cmd
+    else
+      rm $opts "$file"
+    fi
+  else
+    echo "kept $file."
+  fi
+done < /dev/stdin

--- a/bin/keep
+++ b/bin/keep
@@ -1,20 +1,24 @@
 #!/usr/bin/env bash
 
 usage() {
-  echo "usage: $(basename $0) [-h|--help]"
+  echo "usage: $(basename $0) [-h|--help] [-c|--cmd CMD] [-d|--dry-run]"
   echo
   echo 'Keep is a tool for keeping or removing files from an arbitrary list,'
   echo 'interactively. It takes zero or more lines from STDIN and for each one'
   echo 'prompts the user to choose whether to keep (the default) or remove'
   echo 'that file.'
   echo
-  echo '  EXAMPLE:'
+  echo '  EXAMPLES:'
   echo
   echo '  $ ls | keep'
   echo
+  echo '  $ git branch | keep --cmd "git branch -D"'
+  echo
   echo '  OPTIONS:'
   echo
-  echo '  -h|--help show this help text'
+  echo '  -h|--help     show this help text'
+  echo '  -c|--cmd CMD  run CMD for each file not kept (default: rm -rf)'
+  echo '  -d|--dry-run  only echo rm commands, do not execute'
 }
 
 POSITIONAL=()
@@ -32,8 +36,8 @@ case $key in
     DRY_RUN=1
     shift # past argument
     ;;
-    -y|--arg-with-value)
-    VALARG="$2"
+    -c|--cmd)
+    CMD="$2"
     shift # past argument
     shift # past value
     ;;
@@ -47,14 +51,15 @@ done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
 
-opts='-rf' # TODO
+CMD=${CMD:-'rm -rf'}
+
 while read file; do
   read -p "Keep $file (Y/n)? [Ctrl+C to quit] " choice < /dev/tty
   if [[ $choice == 'n' ]] ; then
     if [[ $DRY_RUN ]] ; then
-      echo rm $opts $cmd
+      echo $CMD "$file"
     else
-      rm $opts "$file"
+      $CMD "$file"
     fi
   else
     echo "kept $file."

--- a/bin/keep
+++ b/bin/keep
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 usage() {
-  echo "usage: $(basename $0) [-h|--help] [-c|--cmd CMD] [-d|--dry-run]"
+  echo "usage: $(basename $0) [-h|--help] [-c|--cmd CMD] [-d|--dry-run] [-i|--invert]"
   echo
   echo 'Keep is a tool for keeping or removing files from an arbitrary list,'
   echo 'interactively. It takes zero or more lines from STDIN and for each one'
@@ -18,6 +18,7 @@ usage() {
   echo
   echo '  -h|--help     show this help text'
   echo '  -c|--cmd CMD  run CMD for each file not kept (default: rm -rf)'
+  echo '  -i|--invert   choosing Y[es] means "run CMD"; choosing n[o] is a noop'
   echo '  -d|--dry-run  only echo rm commands, do not execute'
 }
 
@@ -34,6 +35,10 @@ case $key in
     ;;
     -d|--dry-run)
     DRY_RUN=1
+    shift # past argument
+    ;;
+    -i|--invert)
+    INVERT=1
     shift # past argument
     ;;
     -c|--cmd)
@@ -54,8 +59,13 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 CMD=${CMD:-'rm -rf'}
 
 while read file; do
-  read -p "Keep $file (Y/n)? [Ctrl+C to quit] " choice < /dev/tty
-  if [[ $choice == 'n' ]] ; then
+  keep='Keep'
+  if [[ $INVERT ]] ; then
+    echo "keep is INVERTED. You will be prompted to run \`$CMD\` on each file."
+    keep="$CMD"
+  fi
+  read -p "$keep $file (Y/n)? [Ctrl+C to quit] " choice < /dev/tty
+  if [[ ( $INVERT != '1' && $choice == 'n' ) || ( $INVERT && $choice != 'n' ) ]] ; then
     if [[ $DRY_RUN ]] ; then
       echo $CMD "$file"
     else


### PR DESCRIPTION
```
usage: keep [-h|--help] [-c|--cmd CMD] [-d|--dry-run] [-i|--invert]

Keep is a tool for keeping or removing files from an arbitrary list,
interactively. It takes zero or more lines from STDIN and for each one
prompts the user to choose whether to keep (the default) or remove
that file.

  EXAMPLES:

  $ ls | keep

  $ git branch | keep --cmd "git branch -D"

  OPTIONS:

  -h|--help     show this help text
  -c|--cmd CMD  run CMD for each file not kept (default: rm -rf)
  -i|--invert   choosing Y[es] means "run CMD"; choosing n[o] is a noop
  -d|--dry-run  only echo rm commands, do not execute
```